### PR TITLE
Removed lowerInclusive, upperInclusive params from Bucketizer

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -58,4 +58,15 @@ object SchemaUtils {
     val outputFields = schema.fields :+ StructField(colName, dataType, nullable = false)
     StructType(outputFields)
   }
+
+  /**
+   * Appends a new column to the input schema. This fails if the given output column already exists.
+   * @param schema input schema
+   * @param col New column schema
+   * @return new schema with the input column appended
+   */
+  def appendColumn(schema: StructType, col: StructField): StructType = {
+    require(!schema.fieldNames.contains(col.name), s"Column ${col.name} already exists.")
+    StructType(schema.fields :+ col)
+  }
 }

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/BucketizerSuite.scala
@@ -101,6 +101,8 @@ class BucketizerSuite extends FunSuite with MLlibTestSparkContext {
     checkBinarySearch(Array(0.0, 1.0, Double.PositiveInfinity))
     // length 3, with -inf and inf
     checkBinarySearch(Array(Double.NegativeInfinity, 1.0, Double.PositiveInfinity))
+    // length 4, with -inf and inf
+    checkBinarySearch(Array(Double.NegativeInfinity, 0.0, 1.0, Double.PositiveInfinity))
   }
 
   test("Binary search correctness in contrast with linear search, on random data") {


### PR DESCRIPTION
Using splits instead of lowerInclusive, upperInclusive.  Added tests.

@yinxusen Please verify that this update looks good before merging it with your PR.  Thanks!